### PR TITLE
Accelerate regridding/remapping with OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
   set(MOM_memory "dynamic_nonsymmetric")
 endif()
 
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fdefault-real-8 -fPIC -fno-second-underscore -fbacktrace -fno-align-commons -fbounds-check -fcray-pointer")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fdefault-real-8 -fPIC -fno-second-underscore -fbacktrace -fno-align-commons -fbounds-check -fcray-pointer -fopenmp -ffree-line-length-none")
 
 set(MOM_src
   mom6/src/ALE/MOM_regridding.F90

--- a/src/pyale_mod.F90
+++ b/src/pyale_mod.F90
@@ -315,6 +315,7 @@ end subroutine get_AG_diag
            dz_regrid, dt=dt, conv_adjust=.false.)
       if (check_error("regridding_main")) return
 
+      !$omp parallel do private(i, j)
       do j = jsc-1,jec+1
         do i = isc-1,iec+1
           if (CS%G%mask2dT(i,j) == 0) cycle


### PR DESCRIPTION
The remapping will be accelerated regardless of coordinate, but there's only specific support for AG at the moment, unless the other coordinates have their own OpenMP directives.

We're also pointing to a branch of AG which slightly modifies the grid building routine to allocate some work arrays on the heap, to work around a segfault which seems to be a stack overrun due to the work arrays being duplicated for every thread. This is what we want, but the segfault isn't!

Closes #2.