### PR TITLE
Shift supported Python versions along

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Recent commit to master uses `Py_NewRef` which was added in 3.10. I don't think we need the older versions any longer, so we'll track that ABI and above.